### PR TITLE
Use default value option of StorageArea.get()

### DIFF
--- a/src/content/improvements.js
+++ b/src/content/improvements.js
@@ -92,14 +92,9 @@ const addTable = (list, urlPattern) => {
 
 const readURLPattern = () => {
   let url = 'https://google.com/?q=%S';
-  const getting = browser.storage.local.get("url");
+  const getting = browser.storage.local.get({ url });
 
-  return getting.then((config) => {
-    if (config.url) {
-      url = config.url;
-    }
-    return url;
-  }, (err) => {
+  return getting.then((config) => config.url, (err) => {
     console.log(`Error: ${error}`);
     return url;
   });

--- a/src/settings/options.js
+++ b/src/settings/options.js
@@ -10,9 +10,10 @@ const saveOptions = (e) => {
 }
 
 const restoreOptions = () => {
-  var getting = browser.storage.local.get("url");
-  getting.then((result) => {
-    const restoredValue = result.url || DEFAULT_URL;
+  var getting = browser.storage.local.get({
+    "url": DEFAULT_URL
+  });
+  getting.then(({ url: restoredValue }) => {
     document.querySelector("#url").value = restoredValue;
   }, (err) => {
     console.log(`Error: ${error}`);


### PR DESCRIPTION
By passing an object to get() you can specify a default value to return if the value is not set. This is a lot less volatile than trying to detect if a value is set.

One note: this will allow empty URLs.